### PR TITLE
La wave05 query params

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -30,7 +30,7 @@ def validate_id(planet_id):
         abort(make_response({"message": f"{planet_id} not found"}, 404))
     return planet
 
-def process_args(queries):
+def process_kwargs(queries):
     """
     Separate kwargs from HTTP request into separate dicts based on SQLAlchemy query method
     :params:
@@ -65,7 +65,7 @@ def process_args(queries):
 @planets_bp.route("",methods= ["GET"])
 def display_all_planets():
     planet_query = Planet.query
-    attrs, orderby, sels = process_args(request.args.to_dict())
+    attrs, orderby, sels = process_kwargs(request.args.to_dict())
     if attrs:
         planet_query = planet_query.filter_by(**attrs)
     # TO DO: works but only sorts by name currently ascending - need to add modularity

--- a/app/routes.py
+++ b/app/routes.py
@@ -28,11 +28,14 @@ def validate_id(planet_id):
     return planet
 
 
-
 @planets_bp.route("",methods= ["GET"])
 def display_all_planets():
+    planet_name_query = request.args.get("name")
+    if planet_name_query:
+        planets = Planet.query.filter_by(name=planet_name_query)
+    else:
+        planets = Planet.query.all()
     response_planets = []
-    planets = Planet.query.all()
     for planet in planets:
         response_planets.append({
             "id": planet.id,
@@ -80,9 +83,6 @@ def create_planet():
 def update_planet(planet_id):
     request_body = request.get_json()
     planet = validate_id(planet_id)
-    # ~~~ REFACTOR ISSUE ~~~ This line runs but a problem with updating the db 
-    # for attr in request_body:
-    #     planet.attr = request_body[attr]
     planet.name = request_body["name"] if "name" in request_body else planet.name 
     planet.description = request_body["description"] if "description" in request_body else planet.description
     planet.mass = request_body["mass"] if "mass" in request_body else planet.mass
@@ -90,6 +90,7 @@ def update_planet(planet_id):
     return make_response(
         {"message": f"planet #{planet_id} Updated Successfully"}, 200
     )
+
 
 @planets_bp.route("/<planet_id>", methods=["DELETE"])
 def delete_planet(planet_id):


### PR DESCRIPTION
Couple updates for query params feature:

- created helper function process_kwargs() which goes through kwargs in the request and organizes them into separate dicts to be used in each SQLAlchemy query function (e.g. filter_by order_by limit)

- updated display_all_planets() to handle kwargs inputs and create query for response planets

NOTE: next feature to work on would be adding modularity to the order_by method. Currently the order method only has one setting right now, which is to sort by planet name in ascending order.